### PR TITLE
Track age for SSE connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FINT SSE client
 
-[![Build Status](https://travis-ci.org/FINTlibs/fint-sse.svg?branch=master)](https://travis-ci.org/FINTlibs/fint-sse)
-[![Coverage Status](https://coveralls.io/repos/github/FINTlibs/fint-sse/badge.svg?branch=master)](https://coveralls.io/github/FINTlibs/fint-sse?branch=master)
+[![Build Status](https://travis-ci.org/FINTLabs/fint-sse.svg?branch=master)](https://travis-ci.org/FINTLabs/fint-sse)
+[![Coverage Status](https://coveralls.io/repos/github/FINTLabs/fint-sse/badge.svg?branch=master)](https://coveralls.io/github/FINTLabs/fint-sse?branch=master)
 
 Built on [jersey](https://jersey.github.io/documentation/latest/sse.html).
 

--- a/src/main/java/no/fint/sse/AbstractEventListener.java
+++ b/src/main/java/no/fint/sse/AbstractEventListener.java
@@ -32,7 +32,7 @@ public abstract class AbstractEventListener implements EventListener {
 
     @Override
     public void onEvent(InboundEvent inboundEvent) {
-        lastUpdated = System.currentTimeMillis();
+        lastUpdated = System.nanoTime();
         if (inboundEvent.isEmpty())
             return;
         String json = inboundEvent.readData();

--- a/src/main/java/no/fint/sse/AbstractEventListener.java
+++ b/src/main/java/no/fint/sse/AbstractEventListener.java
@@ -20,6 +20,9 @@ public abstract class AbstractEventListener implements EventListener {
 
     static final int MAX_UUIDS = 50;
 
+    @Getter(AccessLevel.PACKAGE)   
+    private volatile long lastUpdated;
+
     @Getter(AccessLevel.PACKAGE)
     private List<String> uuids = new ArrayList<>();
 
@@ -29,6 +32,7 @@ public abstract class AbstractEventListener implements EventListener {
 
     @Override
     public void onEvent(InboundEvent inboundEvent) {
+        lastUpdated = System.currentTimeMillis();
         if (inboundEvent.isEmpty())
             return;
         String json = inboundEvent.readData();

--- a/src/main/java/no/fint/sse/AbstractEventListener.java
+++ b/src/main/java/no/fint/sse/AbstractEventListener.java
@@ -21,7 +21,7 @@ public abstract class AbstractEventListener implements EventListener {
     static final int MAX_UUIDS = 50;
 
     @Getter(AccessLevel.PACKAGE)   
-    private volatile long lastUpdated;
+    private volatile long lastUpdated = System.nanoTime();
 
     @Getter(AccessLevel.PACKAGE)
     private List<String> uuids = new ArrayList<>();

--- a/src/main/java/no/fint/sse/FintSse.java
+++ b/src/main/java/no/fint/sse/FintSse.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class FintSse {
     private FintSseConfig config;
 
+    @Getter
     private FintSseClient fintSseClient;
 
     private List<EventSource> eventSources = new ArrayList<>();

--- a/src/main/java/no/fint/sse/FintSse.java
+++ b/src/main/java/no/fint/sse/FintSse.java
@@ -127,11 +127,11 @@ public class FintSse {
         return eventSources.size() > 0 && eventSources.stream().allMatch(EventSource::isOpen);
     }
 
-    public long getLastUpdated() {
+    public long getAge() {
         if (fintSseClient == null) {
-            return -1;
+            return Long.MAX_VALUE;
         }
-        return fintSseClient.getListener().getLastUpdated();
+        return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - fintSseClient.getListener().getLastUpdated());
     }
 
     private WebTarget getWebTarget() {

--- a/src/main/java/no/fint/sse/FintSse.java
+++ b/src/main/java/no/fint/sse/FintSse.java
@@ -125,6 +125,13 @@ public class FintSse {
         return eventSources.size() > 0 && eventSources.stream().allMatch(EventSource::isOpen);
     }
 
+    public long getLastUpdated() {
+        if (fintSseClient == null) {
+            return -1;
+        }
+        return fintSseClient.getListener().getLastUpdated();
+    }
+
     private WebTarget getWebTarget() {
         Map<String, String> headers = new HashMap<>(fintSseClient.getHeaders());
         if (tokenService != null) {

--- a/src/main/java/no/fint/sse/FintSse.java
+++ b/src/main/java/no/fint/sse/FintSse.java
@@ -12,8 +12,9 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
@@ -28,6 +29,8 @@ public class FintSse {
     private TokenService tokenService;
 
     private AtomicBoolean logConnectionInfo = new AtomicBoolean(true);
+
+    private ScheduledExecutorService scheduledExecutorService;
 
     public FintSse(String sseUrl) {
         this(sseUrl, null, FintSseConfig.builder().build());
@@ -46,6 +49,9 @@ public class FintSse {
         this.sseUrl = sseUrl;
         verifySseUrl();
         this.tokenService = tokenService;
+        if (config.isConcurrentConnections()) {
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        }
     }
 
     private void verifySseUrl() {
@@ -70,14 +76,7 @@ public class FintSse {
     private void connect() {
         createEventSource();
         if (config.isConcurrentConnections()) {
-            ExecutorService executorService = Executors.newFixedThreadPool(1);
-            executorService.submit(() -> {
-                try {
-                    Thread.sleep(config.getSseThreadInterval());
-                    createEventSource();
-                } catch (InterruptedException ignored) {
-                }
-            });
+            scheduledExecutorService.schedule(this::createEventSource, config.getSseThreadInterval(), TimeUnit.MILLISECONDS);
         }
     }
 
@@ -104,6 +103,9 @@ public class FintSse {
     public void close() {
         for (int i = 0; i < eventSources.size(); i++) {
             eventSources.get(i).close();
+        }
+        if (scheduledExecutorService != null) {
+            scheduledExecutorService.shutdownNow();
         }
     }
 

--- a/src/main/java/no/fint/sse/FintSseClient.java
+++ b/src/main/java/no/fint/sse/FintSseClient.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 @Getter
 @AllArgsConstructor
-class FintSseClient {
+public class FintSseClient {
     private AbstractEventListener listener;
     private Map<String, String> headers;
 

--- a/src/test/groovy/no/fint/sse/AbstractEventListenerSpec.groovy
+++ b/src/test/groovy/no/fint/sse/AbstractEventListenerSpec.groovy
@@ -39,7 +39,7 @@ class AbstractEventListenerSpec extends Specification {
         def receivedEvent = listener.getEvent()
 
         then:
-        listener.lastUpdated + 100000 > System.currentTimeMillis()
+        listener.lastUpdated + 100000 > System.nanoTime()
         listener.uuids.size() == 1
         listener.uuids[0] == event.getCorrId()
         receivedEvent.corrId == event.corrId

--- a/src/test/groovy/no/fint/sse/AbstractEventListenerSpec.groovy
+++ b/src/test/groovy/no/fint/sse/AbstractEventListenerSpec.groovy
@@ -27,6 +27,7 @@ class AbstractEventListenerSpec extends Specification {
 
     def "Receive unique InboundEvent and convert it to Event"() {
         given:
+        def start = listener.lastUpdated
         def event = new Event('rogfk.no', 'test', DefaultActions.HEALTH.name(), 'test')
         def inboundEvent = Mock(InboundEvent) {
             readData() >> new ObjectMapper().writeValueAsString(event)
@@ -39,7 +40,7 @@ class AbstractEventListenerSpec extends Specification {
         def receivedEvent = listener.getEvent()
 
         then:
-        listener.lastUpdated + 100000 > System.nanoTime()
+        listener.lastUpdated > start
         listener.uuids.size() == 1
         listener.uuids[0] == event.getCorrId()
         receivedEvent.corrId == event.corrId

--- a/src/test/groovy/no/fint/sse/AbstractEventListenerSpec.groovy
+++ b/src/test/groovy/no/fint/sse/AbstractEventListenerSpec.groovy
@@ -39,6 +39,7 @@ class AbstractEventListenerSpec extends Specification {
         def receivedEvent = listener.getEvent()
 
         then:
+        listener.lastUpdated + 100000 > System.currentTimeMillis()
         listener.uuids.size() == 1
         listener.uuids[0] == event.getCorrId()
         receivedEvent.corrId == event.corrId

--- a/src/test/groovy/no/fint/sse/FintSseSpec.groovy
+++ b/src/test/groovy/no/fint/sse/FintSseSpec.groovy
@@ -33,12 +33,15 @@ class FintSseSpec extends Specification {
         fintSseInst != null
     }
 
-    def "Connect event listener"() {
+    def "Connect event listener and wait for event"() {
         when:
         fintSse.connect(listener)
+        Thread.sleep(150)
+        def lastUpdated = fintSse.lastUpdated
 
         then:
         fintSse.isConnected()
+        lastUpdated > 0
     }
 
     def "Connect event listener with header"() {

--- a/src/test/groovy/no/fint/sse/FintSseSpec.groovy
+++ b/src/test/groovy/no/fint/sse/FintSseSpec.groovy
@@ -37,11 +37,11 @@ class FintSseSpec extends Specification {
         when:
         fintSse.connect(listener)
         Thread.sleep(150)
-        def lastUpdated = fintSse.lastUpdated
+        def age = fintSse.age
 
         then:
         fintSse.isConnected()
-        lastUpdated > 0
+        age < 200
     }
 
     def "Connect event listener with header"() {


### PR DESCRIPTION
This PR adds information on SSE connections with the last updated timestamp.

Can be used by adapters to detect stale connections.